### PR TITLE
960425 - Removed the security issue related namespaces in HTML to PDF code examples

### DIFF
--- a/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/Program.cs
@@ -2,19 +2,17 @@
 
 using Syncfusion.HtmlConverter;
 using Syncfusion.Pdf;
-using System.Runtime.InteropServices;
 
 //Initialize HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Create blink converter settings
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arguments to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-    blinkConverterSettings.AdditionalDelay = 0;
-}
+
+//Set command line arguments to run without the sandbox
+blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
+blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
+blinkConverterSettings.AdditionalDelay = 0;
+
 //Assign Blink converter settings to HTML converter.
 htmlConverter.ConverterSettings = blinkConverterSettings;
 //Convert URL to PDF document.

--- a/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/Program.cs
@@ -8,11 +8,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Create blink converter settings
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
 
-//Set command line arguments to run without the sandbox
-blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-blinkConverterSettings.AdditionalDelay = 0;
-
 //Assign Blink converter settings to HTML converter.
 htmlConverter.ConverterSettings = blinkConverterSettings;
 //Convert URL to PDF document.

--- a/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/README.md
+++ b/HTML to PDF/Blink/Convert-website-URL-to-PDF-document/.NET/Convert-website-URL-to-PDF-document/README.md
@@ -15,7 +15,6 @@ Step 3: **Include necessary namespaces**: Add the following namespaces in your `
    ```csharp
    using Syncfusion.HtmlConverter;
    using Syncfusion.Pdf;
-   using System.Runtime.InteropServices;
    ```
 
 Step 4: **Convert HTML to PDF**: Implement the following code in `Program.cs` to convert a website URL to a PDF file:
@@ -25,12 +24,6 @@ Step 4: **Convert HTML to PDF**: Implement the following code in `Program.cs` to
     HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
     //Create blink converter settings
     BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-    {
-        //Set command line arguments to run without the sandbox.
-        blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-        blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-    }
     //Assign Blink converter settings to HTML converter.
     htmlConverter.ConverterSettings = blinkConverterSettings;
     //Convert URL to PDF document.


### PR DESCRIPTION
Title : Removed the security issue related namespaces in HTML to PDF code examples

Task : https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/960425

What we did in this PR:
Due to security reason on playground application, we are restricting few vulnerable namespaces to execute the code. In Html to pdf sample, we see "System.Runtime" namespace for checking the OS platforms. We removed this code snippet to run the sample in playground.

