### PR TITLE
968984_Removed the command line arguments in the BlinkConverterSettings.

### DIFF
--- a/HTML to PDF/Blink/Access-a-webpage-using-HTTP-GET/.NET/Access-a-webpage-using-HTTP-GET/Program.cs
+++ b/HTML to PDF/Blink/Access-a-webpage-using-HTTP-GET/.NET/Access-a-webpage-using-HTTP-GET/Program.cs
@@ -6,15 +6,6 @@ using System.Runtime.InteropServices;
 
 //Initialize the HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = blinkConverterSettings;
 
 //Set the URL. 
 string url = "https://www.example.com";

--- a/HTML to PDF/Blink/Access-a-webpage-using-HTTP-POST/.NET/Access-a-webpage-using-HTTP-POST/Program.cs
+++ b/HTML to PDF/Blink/Access-a-webpage-using-HTTP-POST/.NET/Access-a-webpage-using-HTTP-POST/Program.cs
@@ -9,12 +9,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Add HTTP post parameters to HttpPostFields.
 settings.HttpPostFields.Add("firstName", "Andrew");
 settings.HttpPostFields.Add("lastName", "Fuller");

--- a/HTML to PDF/Blink/Accessible_PDF_In_HTML_to_PDF/.NET/Accessible PDF/Program.cs
+++ b/HTML to PDF/Blink/Accessible_PDF_In_HTML_to_PDF/.NET/Accessible PDF/Program.cs
@@ -6,12 +6,6 @@ using System.Runtime.InteropServices;
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize the BlinkConverterSettings.
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set true to enable the accessibility tags in PDF generation.
 settings.EnableAccessibilityTags = true;
 //Assign the BlinkConverterSettings to the ConverterSettings property of HtmlToPdfConverter.

--- a/HTML to PDF/Blink/Adjusting-the-HTML-content-size-in-PDF-document/.NET/Adjusting-the-HTML-content-size-in-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Adjusting-the-HTML-content-size-in-PDF-document/.NET/Adjusting-the-HTML-content-size-in-PDF-document/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Create blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set Blink viewport size.
 blinkConverterSettings.ViewPortSize = new Size(800, 0);
 

--- a/HTML to PDF/Blink/Convert-HTML-form-to-PDF-fillable-form/.NET/Convert-HTML-form-to-PDF-fillable-form/Program.cs
+++ b/HTML to PDF/Blink/Convert-HTML-form-to-PDF-fillable-form/.NET/Convert-HTML-form-to-PDF-fillable-form/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Create blink converter settings. 
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set enable form.
 settings.EnableForm = true;
 

--- a/HTML to PDF/Blink/Convert-HTML-to-PDF-in-offline-mode/.NET/Convert-HTML-to-PDF-in-offline-mode/Program.cs
+++ b/HTML to PDF/Blink/Convert-HTML-to-PDF-in-offline-mode/.NET/Convert-HTML-to-PDF-in-offline-mode/Program.cs
@@ -9,12 +9,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 
 //Enable offline mode.
 blinkConverterSettings.EnableOfflineMode = true;

--- a/HTML to PDF/Blink/Convert-form-authenticated-webpage-to-PDF-document/.NET/Convert-form-authenticated-webpage-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-form-authenticated-webpage-to-PDF-document/.NET/Convert-form-authenticated-webpage-to-PDF-document/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Add cookies as name and value pair.
 blinkConverterSettings.Cookies.Add("CookieName1", "CookieValue1");
 blinkConverterSettings.Cookies.Add("CookieName2", "CookieValue2");

--- a/HTML to PDF/Blink/Convert-partial-webpage-to-PDF-document/.NET/Convert-partial-webpage-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-partial-webpage-to-PDF-document/.NET/Convert-partial-webpage-to-PDF-document/Program.cs
@@ -6,15 +6,7 @@ using System.Runtime.InteropServices;
 
 //Initialize the HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = blinkConverterSettings;
+
 //Convert Partial webpage to PDF document. 
 PdfDocument document = htmlConverter.ConvertPartialHtml(Path.GetFullPath(@"Data/Input.html"), "picture");
 

--- a/HTML to PDF/Blink/Convert-the-HTML-string-to-PDF-document/.NET/Convert-the-HTML-string-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-the-HTML-string-to-PDF-document/.NET/Convert-the-HTML-string-to-PDF-document/Program.cs
@@ -6,15 +6,6 @@ using System.Runtime.InteropServices;
 
 //Initialize HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = blinkConverterSettings;
 //HTML string and Base URL.
 string htmlText = "<html><body><img src=\"syncfusion_logo.png\" alt=\"Syncfusion_logo\" width=\"200\" height=\"70\"><p> Hello World</p></body></html>";
 string baseUrl = Path.GetFullPath(@"Data/Resources/");

--- a/HTML to PDF/Blink/Convert-the-HTML-string-to-image-file/.NET/Convert-the-HTML-string-to-image-file/Program.cs
+++ b/HTML to PDF/Blink/Convert-the-HTML-string-to-image-file/.NET/Convert-the-HTML-string-to-image-file/Program.cs
@@ -6,14 +6,6 @@ using System.Runtime.InteropServices;
 
 //Initialize HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = settings;
 //HTML string and Base URL.
 string htmlText = "<html><body><img src=\"syncfusion_logo.png\" alt=\"Syncfusion_logo\" width=\"200\" height=\"70\"><p> Hello World</p></body></html>";
 string baseUrl = Path.GetFullPath(@"Data/Resources/");

--- a/HTML to PDF/Blink/Convert-token-based-authenticated-webpage-to-PDF/.NET/Convert-token-based-authenticated-webpage-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Convert-token-based-authenticated-webpage-to-PDF/.NET/Convert-token-based-authenticated-webpage-to-PDF/Program.cs
@@ -9,11 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings.
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Add a bearer token to login a webpage.
 settings.HttpRequestHeaders.Add("User-Agent", "Syncfusion WebKit HTML converter");
 

--- a/HTML to PDF/Blink/Convert-website-URL-to-image-file/.NET/Convert-website-URL-to-image-file/Program.cs
+++ b/HTML to PDF/Blink/Convert-website-URL-to-image-file/.NET/Convert-website-URL-to-image-file/Program.cs
@@ -6,15 +6,6 @@ using System.Runtime.InteropServices;
 
 //Initialize HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = blinkConverterSettings;
 //Convert URL to Image.
 Image image = htmlConverter.ConvertToImage("https://www.google.com");
 

--- a/HTML to PDF/Blink/Convert-windows-authenticated-webpage-to-PDF-document/.NET/Convert-windows-authenticated-webpage-to-PDF-document/Program.cs
+++ b/HTML to PDF/Blink/Convert-windows-authenticated-webpage-to-PDF-document/.NET/Convert-windows-authenticated-webpage-to-PDF-document/Program.cs
@@ -9,11 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Create blink converter settings.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Set username and password. 
 blinkConverterSettings.Username = "username";
 blinkConverterSettings.Password = "password";

--- a/HTML to PDF/Blink/Create-TOC-while-converting-HTML-to-PDF/.NET/Create-TOC-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Create-TOC-while-converting-HTML-to-PDF/.NET/Create-TOC-while-converting-HTML-to-PDF/Program.cs
@@ -9,11 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Set enable table of contents.
 settings.EnableToc = true;
 

--- a/HTML to PDF/Blink/Create-custom-style-TOC-when-converting-HTML-to-PDF/.NET/Create-custom-style-TOC-when-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Create-custom-style-TOC-when-converting-HTML-to-PDF/.NET/Create-custom-style-TOC-when-converting-HTML-to-PDF/Program.cs
@@ -12,11 +12,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Set enable table of contents.
 settings.EnableToc = true;
 

--- a/HTML to PDF/Blink/Creating-bookmarks-while-converting-HTML-to-PDF/.NET/Creating-bookmarks-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Creating-bookmarks-while-converting-HTML-to-PDF/.NET/Creating-bookmarks-while-converting-HTML-to-PDF/Program.cs
@@ -9,11 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Set enable bookmarks.
 settings.EnableBookmarks = true;
 

--- a/HTML to PDF/Blink/Disable-JavaScript-when-convert-HTML-to-PDF/.NET/Disable-JavaScript-when-convert-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Disable-JavaScript-when-convert-HTML-to-PDF/.NET/Disable-JavaScript-when-convert-HTML-to-PDF/Program.cs
@@ -9,12 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Disable JavaScript; By default, true.
 blinkConverterSettings.EnableJavaScript = false;
 

--- a/HTML to PDF/Blink/Disable-URL-links-while-converting-HTML-to-PDF/.NET/Disable-URL-links-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Disable-URL-links-while-converting-HTML-to-PDF/.NET/Disable-URL-links-while-converting-HTML-to-PDF/Program.cs
@@ -9,11 +9,7 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize blink converter settings.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
+
 //Enable hyperlinks; By default - true.
 blinkConverterSettings.EnableHyperLink = false;
 

--- a/HTML to PDF/Blink/Get-height-of-HTML-content-in-PDF/.NET/Get-height-of-HTML-content-in-PDF/Program.cs
+++ b/HTML to PDF/Blink/Get-height-of-HTML-content-in-PDF/.NET/Get-height-of-HTML-content-in-PDF/Program.cs
@@ -8,14 +8,6 @@ using System.Runtime.InteropServices;
 
 //Initialize the HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
-BlinkConverterSettings settings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-//Assign Blink converter settings to HTML converter.
-htmlConverter.ConverterSettings = settings;
 PdfLayoutResult layoutResult = null;
 
 //Convert URL to PDF document. 

--- a/HTML to PDF/Blink/HTML-Footer-Background-Colour/.NET/HTML-Footer-Background-Colour/Program.cs
+++ b/HTML to PDF/Blink/HTML-Footer-Background-Colour/.NET/HTML-Footer-Background-Colour/Program.cs
@@ -7,11 +7,6 @@ using System.Runtime.InteropServices;
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set the Blink viewport size.
 blinkConverterSettings.ViewPortSize = new Size(1280, 0);
 //Set the html margin-top value based on the html header height and margin-top value.

--- a/HTML to PDF/Blink/HTML-Header-and-Footer/.NET/HTML-Header-and-Footer/Program.cs
+++ b/HTML to PDF/Blink/HTML-Header-and-Footer/.NET/HTML-Header-and-Footer/Program.cs
@@ -10,11 +10,6 @@ namespace HTML_Header_and_Footer {
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             //Initialize blink converter settings.
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
 			//Set the Blink viewport size.
             blinkConverterSettings.ViewPortSize = new Size(1280, 0);
             //Reade the html header and footer text from the html file or you can set html string also.

--- a/HTML to PDF/Blink/HTML-to-PDF-Enable-Autoscaling/.NET/HTML-to-PDF-Enable-Autoscaling/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-Enable-Autoscaling/.NET/HTML-to-PDF-Enable-Autoscaling/Program.cs
@@ -6,16 +6,8 @@ using System.Runtime.InteropServices;
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 // Initialize BlinkConverterSettings to configure the Blink rendering engine.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    //Set command line arugument to run without the sandbox.
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-
 // Enables automatic scaling to adjust the HTML content to fit the PDF's dimensions.
 blinkConverterSettings.EnableAutoScaling = true;
-
 // Assigns the Blink settings to the HTML to PDF converter.
 htmlConverter.ConverterSettings = blinkConverterSettings;
 // Converts the HTML file to a PDF document, using the path of the HTML file.

--- a/HTML to PDF/Blink/HTML-to-PDF-Header-and-footer/.NET/HTML-to-PDF-Header-and-footer/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-Header-and-footer/.NET/HTML-to-PDF-Header-and-footer/Program.cs
@@ -10,11 +10,6 @@ namespace HTML_to_PDF_Header_and_footer {
             //Initialize HTML to PDF converter.
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
             //Create PDF page template element for header with bounds.
             PdfPageTemplateElement header = new PdfPageTemplateElement(new RectangleF(0, 0, blinkConverterSettings.PdfPageSize.Width, 50));
             //Create font and brush for header element.

--- a/HTML to PDF/Blink/HTML-to-PDF-margin-customization/.NET/HTML-to-PDF-margin-customization/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-margin-customization/.NET/HTML-to-PDF-margin-customization/Program.cs
@@ -9,11 +9,6 @@ namespace HTML_to_PDF_margin_customization {
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             //Initialize blink converter settings. 
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
             //Set the margin.
             blinkConverterSettings.Margin.All = 50;
             //Assign Blink converter settings to HTML converter.

--- a/HTML to PDF/Blink/HTML-to-PDF-page-orientation-customization/.NET/HTML-to-PDF-page-orientation-customization/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-page-orientation-customization/.NET/HTML-to-PDF-page-orientation-customization/Program.cs
@@ -9,11 +9,6 @@ namespace HTML_to_PDF_page_orientation_customization {
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             //Initialize blink converter settings. 
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
             //Set the Orientation.
             blinkConverterSettings.Orientation = PdfPageOrientation.Landscape;
             //Assign Blink converter settings to HTML converter.

--- a/HTML to PDF/Blink/HTML-to-PDF-page-size-customization/.NET/HTML-to-PDF-page-size-customization/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-page-size-customization/.NET/HTML-to-PDF-page-size-customization/Program.cs
@@ -9,11 +9,6 @@ namespace HTML_to_PDF_page_size_customization {
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             //Initialize blink converter settings. 
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
             //Set the page size.
             blinkConverterSettings.PdfPageSize = PdfPageSize.A4;
             //Assign Blink converter settings to HTML converter.

--- a/HTML to PDF/Blink/HTML-to-PDF-rotate-page/.NET/HTML-to-PDF-rotate-page/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-rotate-page/.NET/HTML-to-PDF-rotate-page/Program.cs
@@ -9,11 +9,6 @@ namespace HTML_to_PDF_rotate_page {
             HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
             //Initialize blink converter settings. 
             BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-				blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-			}
             //Set the page rotate.
             blinkConverterSettings.PageRotateAngle = PdfPageRotateAngle.RotateAngle90;
             //Assign Blink converter settings to the HTML converter.

--- a/HTML to PDF/Blink/HTML-to-PDF-scale-property/.NET/Scale_property_in_HTML_converter/Program.cs
+++ b/HTML to PDF/Blink/HTML-to-PDF-scale-property/.NET/Scale_property_in_HTML_converter/Program.cs
@@ -7,11 +7,6 @@ using System.Runtime.InteropServices;
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize blink converter settings.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set the Scale.
 blinkConverterSettings.Scale = 1.0f;
 //Assign Blink converter settings to HTML converter.

--- a/HTML to PDF/Blink/Image_Background_In_HTML_to_PDF/.NET/Image_Background_In_HTML_to_PDF/Program.cs
+++ b/HTML to PDF/Blink/Image_Background_In_HTML_to_PDF/.NET/Image_Background_In_HTML_to_PDF/Program.cs
@@ -9,11 +9,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize the BlinkConverterSettings
 BlinkConverterSettings settings = new BlinkConverterSettings();
 
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    settings.CommandLineArguments.Add("--no-sandbox");
-    settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set the Image Background color.
 settings.ImageBackgroundColor = Color.Transparent;
 

--- a/HTML to PDF/Blink/Inject_custom_CSS_to_HTML/.NET/Inject_custom_CSS_to_HTML/Program.cs
+++ b/HTML to PDF/Blink/Inject_custom_CSS_to_HTML/.NET/Inject_custom_CSS_to_HTML/Program.cs
@@ -8,11 +8,6 @@ using System.Runtime.InteropServices;
 //Initialize the HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set the Blink viewport size.
 blinkConverterSettings.ViewPortSize = new Size(1280, 0);
 blinkConverterSettings.Margin.All = 30;

--- a/HTML to PDF/Blink/Inject_custom_JavaScript_to_HTML/.NET/Inject_custom_JavaScript_to_HTML/Program.cs
+++ b/HTML to PDF/Blink/Inject_custom_JavaScript_to_HTML/.NET/Inject_custom_JavaScript_to_HTML/Program.cs
@@ -11,11 +11,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 
 //Initialize the blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set the Blink viewport size.
 blinkConverterSettings.ViewPortSize = new Size(1280, 0);
 blinkConverterSettings.Margin.All = 30;

--- a/HTML to PDF/Blink/Optimize-HTML-to-PDF-performance/.NET/Optimize-HTML-to-PDF-performance/Program.cs
+++ b/HTML to PDF/Blink/Optimize-HTML-to-PDF-performance/.NET/Optimize-HTML-to-PDF-performance/Program.cs
@@ -19,11 +19,6 @@ for (int i = 0; i < 10; i++)
 {
     //Initialize the blink converter settings. 
     BlinkConverterSettings settings = new BlinkConverterSettings();
-	if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-	{
-		settings.CommandLineArguments.Add("--no-sandbox");
-		settings.CommandLineArguments.Add("--disable-setuid-sandbox");
-	}
     settings.AdditionalDelay = 1000;
     settings.EnableJavaScript = true;
     //Assign the settings to HTML converter.

--- a/HTML to PDF/Blink/Selection-of-media-type-while-converting-HTML-to-PDF/.NET/Selection-of-media-type-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Selection-of-media-type-while-converting-HTML-to-PDF/.NET/Selection-of-media-type-while-converting-HTML-to-PDF/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Create blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
 
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-
 //Set print media type.
 blinkConverterSettings.MediaType = MediaType.Screen;
 

--- a/HTML to PDF/Blink/Set-additional-delay-while-converting-HTML-to-PDF/.NET/Set-additional-delay-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Set-additional-delay-while-converting-HTML-to-PDF/.NET/Set-additional-delay-while-converting-HTML-to-PDF/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize blink converter settings.  
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
 
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-
 // Set additional delay; units in milliseconds.
 blinkConverterSettings.AdditionalDelay = 3000;
 

--- a/HTML to PDF/Blink/Set-temporary-path-while-converting-HTML-to-PDF/.NET/Set-temporary-path-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Set-temporary-path-while-converting-HTML-to-PDF/.NET/Set-temporary-path-while-converting-HTML-to-PDF/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Set blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
 
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-
 //Set Temporary Path to generate temporary files.
 blinkConverterSettings.TempPath = @"D:/HtmlConversion/Temp/";
 

--- a/HTML to PDF/Blink/Set-windows-status-while-converting-HTML-to-PDF/.NET/Set-windows-status-while-converting-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Set-windows-status-while-converting-HTML-to-PDF/.NET/Set-windows-status-while-converting-HTML-to-PDF/Program.cs
@@ -10,12 +10,6 @@ HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Create blink converter settings. 
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
 
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
-
 //Set windows status.
 blinkConverterSettings.WindowStatus = "completed";
 

--- a/HTML to PDF/Blink/Set_blink_path_in_HTML_to_PDF/.NET/Set_blink_path_in_HTML_to_PDF/Program.cs
+++ b/HTML to PDF/Blink/Set_blink_path_in_HTML_to_PDF/.NET/Set_blink_path_in_HTML_to_PDF/Program.cs
@@ -7,11 +7,6 @@ using System.Runtime.InteropServices;
 //Initialize HTML to PDF converter.
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 //Set Blink binaries path.
 blinkConverterSettings.BlinkPath = @"../../../BlinkBinaries/";
 //Assign Blink converter settings to HTML converter.

--- a/HTML to PDF/Blink/Time-out-support-in-HTML-to-PDF/.NET/Time-out-support-in-HTML-to-PDF/Program.cs
+++ b/HTML to PDF/Blink/Time-out-support-in-HTML-to-PDF/.NET/Time-out-support-in-HTML-to-PDF/Program.cs
@@ -7,11 +7,6 @@ using System.Runtime.InteropServices;
 HtmlToPdfConverter htmlConverter = new HtmlToPdfConverter();
 //Initialize the blink converter settings.
 BlinkConverterSettings blinkConverterSettings = new BlinkConverterSettings();
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-{
-    blinkConverterSettings.CommandLineArguments.Add("--no-sandbox");
-    blinkConverterSettings.CommandLineArguments.Add("--disable-setuid-sandbox");
-}
 // Set the conversion timeout to 5000 milliseconds 
 blinkConverterSettings.ConversionTimeout = 5000;
 //Assign Blink converter settings to HTML converter


### PR DESCRIPTION
Hi Team,

Task link: [UG documentation 968984 Need to remove the commandline arguments in the github samples](https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/968984)

Regards,
Karmegam